### PR TITLE
Use name/year/thumbnail from collection API

### DIFF
--- a/src/Containers/App.js
+++ b/src/Containers/App.js
@@ -44,6 +44,7 @@ const App = () => {
 			.then(data => {
 				let numGames;
 				let gameIds = [];
+				let collectionData = {};
 				let arrayOfArrays = [];
 
 				XML2JS.parseString(data, (err, result) => { // xml2js: converts XML to JSON
@@ -52,6 +53,7 @@ const App = () => {
 
 						result.items.item.forEach(game => {
 							gameIds.push(game.$.objectid);
+							collectionData[game.$.objectid] = game;
 						});
 					}
 
@@ -70,7 +72,7 @@ const App = () => {
 		
 					.then(xml => {
 						return XML2JS.parseString(xml, (err, result) => {
-							gameDataConversions(result.items.item);
+							gameDataConversions(result.items.item, collectionData);
 		
 							setGameList(gameList => gameList.concat(result.items.item));
 
@@ -86,7 +88,7 @@ const App = () => {
 		
 						.then(xml => {
 							return XML2JS.parseString(xml, (err, result) => {
-								gameDataConversions(result.items.item);
+								gameDataConversions(result.items.item, collectionData);
 			
 								setGameList(gameList => gameList.concat(result.items.item));
 							})

--- a/src/utils/gameDataConversions.js
+++ b/src/utils/gameDataConversions.js
@@ -1,6 +1,10 @@
 /* Going through the array and changing default values and converting string numbers to actual numbers so that the Table can sort them correctly */
-const gameDataConversions = (array) => {
+const gameDataConversions = (array, collectionData) => {
 	array.forEach(game => {
+		game.name[0].$.value = collectionData[game.$.id].name[0]._;
+		if (collectionData[game.$.id].thumbnail)
+			game.thumbnail[0] = collectionData[game.$.id].thumbnail[0];
+
 		if (game.statistics[0].ratings[0].ranks[0].rank[0].$.value === 'Not Ranked')
 			game.statistics[0].ratings[0].ranks[0].rank[0].$.value = 'N/A';
 		else {
@@ -19,8 +23,10 @@ const gameDataConversions = (array) => {
 		if (isNaN(game.maxplaytime[0].$.value))
 			game.maxplaytime[0].$.value = '--';
 
-		if (game.yearpublished[0].$.value === undefined)
-			game.yearpublished[0].$.value = ['--'];
+		if (collectionData[game.$.id].yearpublished)
+			game.yearpublished[0].$.value = collectionData[game.$.id].yearpublished[0];
+		if (game.yearpublished[0].$.value === undefined || game.yearpublished[0].$.value === 0)
+			game.yearpublished[0].$.value = '--';
 	})
 }
 


### PR DESCRIPTION
Some versions of games (different language etc) have their own names and thumbnails. The BGG collection API uses the version-specific values, so we can match the BGG collection view behavior by simply not overriding these with values from the thing API.

For example, I have "Take 5" in my collection, but it's actually the German version titled "6 Nimmt". On https://betterbggcollection.com/?username=nkorth you can see it says Take 5 while on BGG https://boardgamegeek.com/collection/user/nkorth it has the correct name and thumbnail.

(As a side note, when testing this I noticed that the CORS workaround seems to no longer be required! Apparently [only a couple endpoints](https://boardgamegeek.com/thread/2624587/article/37298832#37298832) require it now.)